### PR TITLE
support cv_bridge_python3 with python2 workspace

### DIFF
--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -22,12 +22,23 @@ if os.environ['ROS_PYTHON_VERSION'] == '3':
 else:
     ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
     if len(ws_python3_paths) == 0:
-        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
-        ws_python2_path = ws_python2_paths[0]
-        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-        sys.path = [ws_python3_path] + sys.path
-        from cv_bridge import CvBridge
-        sys.path.remove(ws_python3_path)
+        # search cv_bridge in workspace and append
+        ws_python2_paths = [
+            p for p in sys.path if 'devel/lib/python2.7' in p]
+        for ws_python2_path in ws_python2_paths:
+            ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+            if os.path.exists(os.path.join(ws_python3_path, 'cv_bridge')):
+                ws_python3_paths.append(ws_python3_path)
+        if len(ws_python3_paths) == 0:
+            opt_python3_path = '/opt/ros/{}/lib/python3/dist-packages'.format(
+                os.getenv('ROS_DISTRO'))
+            sys.path = [opt_python3_path] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(opt_python3_path)
+        else:
+            sys.path = [ws_python3_paths[0]] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(ws_python3_paths[0])
     else:
         from cv_bridge import CvBridge
 

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -20,11 +20,16 @@ else:
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     from cv_bridge import CvBridge
 else:
-    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
-    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-    sys.path = [ws_python3_path] + sys.path
-    from cv_bridge import CvBridge
-    sys.path.remove(ws_python3_path)
+    ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
+    if len(ws_python3_paths) == 0:
+        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
+        ws_python2_path = ws_python2_paths[0]
+        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+        sys.path = [ws_python3_path] + sys.path
+        from cv_bridge import CvBridge
+        sys.path.remove(ws_python3_path)
+    else:
+        from cv_bridge import CvBridge
 
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -8,7 +8,7 @@ import re
 import sys
 import threading
 
-# OpenCV import for python3.5
+# OpenCV import for python3
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     import cv2
 else:
@@ -16,7 +16,16 @@ else:
     import cv2  # NOQA
     sys.path.append('/opt/ros/{}/lib/python2.7/dist-packages'.format(os.getenv('ROS_DISTRO')))  # NOQA
 
-from cv_bridge import CvBridge
+# cv_bridge_python3 import
+if os.environ['ROS_PYTHON_VERSION'] == '3':
+    from cv_bridge import CvBridge
+else:
+    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
+    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+    sys.path = [ws_python3_path] + sys.path
+    from cv_bridge import CvBridge
+    sys.path.remove(ws_python3_path)
+
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE
 from edgetpu.basic.edgetpu_utils import ListEdgeTpuPaths

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -21,12 +21,23 @@ if os.environ['ROS_PYTHON_VERSION'] == '3':
 else:
     ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
     if len(ws_python3_paths) == 0:
-        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
-        ws_python2_path = ws_python2_paths[0]
-        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-        sys.path = [ws_python3_path] + sys.path
-        from cv_bridge import CvBridge
-        sys.path.remove(ws_python3_path)
+        # search cv_bridge in workspace and append
+        ws_python2_paths = [
+            p for p in sys.path if 'devel/lib/python2.7' in p]
+        for ws_python2_path in ws_python2_paths:
+            ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+            if os.path.exists(os.path.join(ws_python3_path, 'cv_bridge')):
+                ws_python3_paths.append(ws_python3_path)
+        if len(ws_python3_paths) == 0:
+            opt_python3_path = '/opt/ros/{}/lib/python3/dist-packages'.format(
+                os.getenv('ROS_DISTRO'))
+            sys.path = [opt_python3_path] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(opt_python3_path)
+        else:
+            sys.path = [ws_python3_paths[0]] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(ws_python3_paths[0])
     else:
         from cv_bridge import CvBridge
 

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -7,7 +7,7 @@ import os
 import sys
 import threading
 
-# OpenCV import for python3.5
+# OpenCV import for python3
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     import cv2
 else:
@@ -15,7 +15,16 @@ else:
     import cv2  # NOQA
     sys.path.append('/opt/ros/{}/lib/python2.7/dist-packages'.format(os.getenv('ROS_DISTRO')))  # NOQA
 
-from cv_bridge import CvBridge
+# cv_bridge_python3 import
+if os.environ['ROS_PYTHON_VERSION'] == '3':
+    from cv_bridge import CvBridge
+else:
+    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
+    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+    sys.path = [ws_python3_path] + sys.path
+    from cv_bridge import CvBridge
+    sys.path.remove(ws_python3_path)
+
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE
 from edgetpu.basic.edgetpu_utils import ListEdgeTpuPaths

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -19,11 +19,16 @@ else:
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     from cv_bridge import CvBridge
 else:
-    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
-    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-    sys.path = [ws_python3_path] + sys.path
-    from cv_bridge import CvBridge
-    sys.path.remove(ws_python3_path)
+    ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
+    if len(ws_python3_paths) == 0:
+        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
+        ws_python2_path = ws_python2_paths[0]
+        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+        sys.path = [ws_python3_path] + sys.path
+        from cv_bridge import CvBridge
+        sys.path.remove(ws_python3_path)
+    else:
+        from cv_bridge import CvBridge
 
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -23,12 +23,23 @@ if os.environ['ROS_PYTHON_VERSION'] == '3':
 else:
     ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
     if len(ws_python3_paths) == 0:
-        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
-        ws_python2_path = ws_python2_paths[0]
-        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-        sys.path = [ws_python3_path] + sys.path
-        from cv_bridge import CvBridge
-        sys.path.remove(ws_python3_path)
+        # search cv_bridge in workspace and append
+        ws_python2_paths = [
+            p for p in sys.path if 'devel/lib/python2.7' in p]
+        for ws_python2_path in ws_python2_paths:
+            ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+            if os.path.exists(os.path.join(ws_python3_path, 'cv_bridge')):
+                ws_python3_paths.append(ws_python3_path)
+        if len(ws_python3_paths) == 0:
+            opt_python3_path = '/opt/ros/{}/lib/python3/dist-packages'.format(
+                os.getenv('ROS_DISTRO'))
+            sys.path = [opt_python3_path] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(opt_python3_path)
+        else:
+            sys.path = [ws_python3_paths[0]] + sys.path
+            from cv_bridge import CvBridge
+            sys.path.remove(ws_python3_paths[0])
     else:
         from cv_bridge import CvBridge
 

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -9,7 +9,7 @@ import re
 import sys
 import threading
 
-# OpenCV import for python3.5
+# OpenCV import for python3
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     import cv2
 else:
@@ -17,8 +17,17 @@ else:
     import cv2  # NOQA
     sys.path.append('/opt/ros/{}/lib/python2.7/dist-packages'.format(os.getenv('ROS_DISTRO')))  # NOQA
 
+# cv_bridge_python3 import
+if os.environ['ROS_PYTHON_VERSION'] == '3':
+    from cv_bridge import CvBridge
+else:
+    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
+    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+    sys.path = [ws_python3_path] + sys.path
+    from cv_bridge import CvBridge
+    sys.path.remove(ws_python3_path)
+
 from chainercv.visualizations import vis_semantic_segmentation
-from cv_bridge import CvBridge
 from edgetpu.basic.basic_engine import BasicEngine
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_ASSIGNED
 from edgetpu.basic.edgetpu_utils import EDGE_TPU_STATE_NONE

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -21,11 +21,16 @@ else:
 if os.environ['ROS_PYTHON_VERSION'] == '3':
     from cv_bridge import CvBridge
 else:
-    ws_python2_path = [p for p in sys.path if 'devel/lib/python2.7' in p][0]
-    ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
-    sys.path = [ws_python3_path] + sys.path
-    from cv_bridge import CvBridge
-    sys.path.remove(ws_python3_path)
+    ws_python3_paths = [p for p in sys.path if 'devel/lib/python3' in p]
+    if len(ws_python3_paths) == 0:
+        ws_python2_paths = [p for p in sys.path if 'devel/lib/python2.7' in p]
+        ws_python2_path = ws_python2_paths[0]
+        ws_python3_path = ws_python2_path.replace('python2.7', 'python3')
+        sys.path = [ws_python3_path] + sys.path
+        from cv_bridge import CvBridge
+        sys.path.remove(ws_python3_path)
+    else:
+        from cv_bridge import CvBridge
 
 from chainercv.visualizations import vis_semantic_segmentation
 from edgetpu.basic.basic_engine import BasicEngine


### PR DESCRIPTION
this PR enables to run `coral_usb_ros` in normal workspace with `cv_bridge_python3`.
https://github.com/jsk-ros-pkg/vision_opencv_python3

@k-okada 
In order to run with `cv_bridge_python3`, I need to load `python3` `PYTHONPATH` manually.
https://github.com/knorth55/coral_usb_ros/blob/1dcb5d550a94c99692154bde158d0954b4fae563/python/coral_usb/detector_base.py#L19-L32