### PR TITLE
use ros-testing for docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,8 @@ RUN if [ -f "/etc/apt/sources.list.d/ros1-latest.list" ]; then \
     fi
 RUN apt-get update && apt-get install -y wget curl git
 RUN curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
-RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros1-latest.list
-# RUN echo "deb http://packages.ros.org/ros-testing/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros1-latest.list
+# RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros1-latest.list
+RUN echo "deb http://packages.ros.org/ros-testing/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros1-latest.list
 
 # FIXME: https://github.com/start-jsk/jsk_apc/pull/2664
 RUN apt-get update && apt-get dist-upgrade -y &&  \


### PR DESCRIPTION
use `ros-testing` for docker build.
`cv_bridge_python3` is not released yet in `ros`, so I'm waiting for the next sync.