### PR TITLE
add ListNodes service in edgetpu_node_manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_service_files(
   FILES
   StartNode.srv
   StopNode.srv
+  ListNodes.srv
 )
 
 generate_messages()

--- a/python/coral_usb/node_manager.py
+++ b/python/coral_usb/node_manager.py
@@ -10,6 +10,8 @@ from coral_usb.object_detector import EdgeTPUPanoramaObjectDetector
 from coral_usb.semantic_segmenter import EdgeTPUPanoramaSemanticSegmenter
 from coral_usb.semantic_segmenter import EdgeTPUSemanticSegmenter
 
+from coral_usb.srv import ListNodes
+from coral_usb.srv import ListNodesResponse
 from coral_usb.srv import StartNode
 from coral_usb.srv import StartNodeResponse
 from coral_usb.srv import StopNode
@@ -41,6 +43,8 @@ class EdgeTPUNodeManager(object):
             '~start', StartNode, self._start_cb)
         self.stop_server = rospy.Service(
             '~stop', StopNode, self._stop_cb)
+        self.list_server = rospy.Service(
+            '~list', ListNodes, self._list_cb)
 
         if default is not None:
             self._start_node(default)
@@ -103,3 +107,6 @@ class EdgeTPUNodeManager(object):
     def _stop_cb(self, req):
         success = self._stop_node()
         return StopNodeResponse(success)
+
+    def _list_cb(self, req):
+        return ListNodesResponse(node_names=self.node_names)

--- a/srv/ListNodes.srv
+++ b/srv/ListNodes.srv
@@ -1,0 +1,2 @@
+---
+string[] node_names


### PR DESCRIPTION
add `ListNodes` service in edgetpu_node_manager to show candidates.

```
fetch@fetch1075:~$ rosservice call /edgetpu_human_node_manager/list
node_names: 
  - edgetpu_human_pose_estimator
  - edgetpu_panorama_human_pose_estimator
fetch@fetch1075:~$ rosservice call /edgetpu_human_node_manager/start "name: 'edgetpu_panorama_human_pose_estimator'" 
success: True
```

```
fetch@fetch1075:~$ rosservice call /edgetpu_object_node_manager/list
node_names: 
  - edgetpu_object_detector
  - edgetpu_panorama_object_detector
fetch@fetch1075:~$ rosservice call /edgetpu_object_node_manager/start "name: 'edgetpu_panorama_object_detector'" 
success: True
```