### PR TITLE
Set the format of compressed image following image_transport.

### DIFF
--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -325,7 +325,8 @@ class EdgeTPUDetectorBase(ConnectionBasedTransport):
             # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
-            vis_compressed_msg.format = "jpeg"
+            # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
+            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()

--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -326,7 +326,8 @@ class EdgeTPUDetectorBase(ConnectionBasedTransport):
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
-            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
+            vis_compressed_msg.format = vis_img.encoding \
+                + '; jpeg compressed rgb8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -353,7 +353,8 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
-            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
+            vis_compressed_msg.format = vis_img.encoding \
+                + '; jpeg compressed rgb8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -352,7 +352,8 @@ class EdgeTPUHumanPoseEstimator(ConnectionBasedTransport):
             # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
-            vis_compressed_msg.format = "jpeg"
+            # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
+            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -284,7 +284,8 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
             # publish compressed http://wiki.ros.org/rospy_tutorials/Tutorials/WritingImagePublisherSubscriber  # NOQA
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
-            vis_compressed_msg.format = "jpeg"
+            # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
+            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -285,7 +285,8 @@ class EdgeTPUSemanticSegmenter(ConnectionBasedTransport):
             vis_compressed_msg = CompressedImage()
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
-            vis_compressed_msg.format = 'rgb8; jpeg compressed bgr8'
+            vis_compressed_msg.format = vis_img.encoding \
+                + '; jpeg compressed rgb8'
             vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
             vis_compressed_msg.data = np.array(
                 cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()


### PR DESCRIPTION
In image_transport, the character compressed is added to the format before compressing with; as the delimiter.
https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116
https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_depth_image_transport/src/codec.cpp#L234

Related to https://github.com/jsk-ros-pkg/jsk_common/pull/1738