### PR TITLE
fix typo in compressed image publish

### DIFF
--- a/python/coral_usb/detector_base.py
+++ b/python/coral_usb/detector_base.py
@@ -188,9 +188,9 @@ class EdgeTPUDetectorBase(EdgeTPUNodeBase):
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
             vis_compressed_msg.format = encoding + '; jpeg compressed bgr8'
-            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_img_bgr = cv2.cvtColor(vis_img, cv2.COLOR_RGB2BGR)
             vis_compressed_msg.data = np.array(
-                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+                cv2.imencode('.jpg', vis_img_bgr)[1]).tostring()
             self.pub_image_compressed.publish(vis_compressed_msg)
 
 

--- a/python/coral_usb/human_pose_estimator.py
+++ b/python/coral_usb/human_pose_estimator.py
@@ -238,9 +238,9 @@ class EdgeTPUHumanPoseEstimator(EdgeTPUNodeBase):
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
             vis_compressed_msg.format = encoding + '; jpeg compressed bgr8'
-            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_img_bgr = cv2.cvtColor(vis_img, cv2.COLOR_RGB2BGR)
             vis_compressed_msg.data = np.array(
-                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+                cv2.imencode('.jpg', vis_img_bgr)[1]).tostring()
             self.pub_image_compressed.publish(vis_compressed_msg)
 
 

--- a/python/coral_usb/semantic_segmenter.py
+++ b/python/coral_usb/semantic_segmenter.py
@@ -152,9 +152,9 @@ class EdgeTPUSemanticSegmenter(EdgeTPUNodeBase):
             vis_compressed_msg.header = header
             # image format https://github.com/ros-perception/image_transport_plugins/blob/f0afd122ed9a66ff3362dc7937e6d465e3c3ccf7/compressed_image_transport/src/compressed_publisher.cpp#L116  # NOQA
             vis_compressed_msg.format = encoding + '; jpeg compressed bgr8'
-            vis_img_rgb = cv2.cvtColor(vis_img, cv2.COLOR_BGR2RGB)
+            vis_img_bgr = cv2.cvtColor(vis_img, cv2.COLOR_RGB2BGR)
             vis_compressed_msg.data = np.array(
-                cv2.imencode('.jpg', vis_img_rgb)[1]).tostring()
+                cv2.imencode('.jpg', vis_img_bgr)[1]).tostring()
             self.pub_image_compressed.publish(vis_compressed_msg)
 
 


### PR DESCRIPTION
this PR fix typ in compressd image publish.
the code does the same thing, but the BGR and RGB order was wrong.