### PR TITLE
fix typo in node_base.py

### DIFF
--- a/python/coral_usb/node_base.py
+++ b/python/coral_usb/node_base.py
@@ -215,7 +215,7 @@ class EdgeTPUNodeBase(ConnectionBasedTransport):
         rospy.logerr('visualize_cb is not implemented.')
 
     def config_cb(self, config, level):
-        rospy.logerr('image_cb is not implemented.')
+        rospy.logerr('config_cb is not implemented.')
 
 
 class DummyEdgeTPUNodeBase(EdgeTPUNodeBase):


### PR DESCRIPTION
this PR fix typo in `node_base.py`