### PR TITLE
[ci] skip python key in kinetic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
             UPSTREAM_WORKSPACE: '.ci.rosinstall.kinetic'
             UPSTREAM_CMAKE_ARGS: '-DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.5m -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so'
             ADDITIONAL_DEBS: 'python3-catkin-pkg-modules python3-rospkg-modules python3-numpy ros-kinetic-opencv3 python3-venv python3-empy python-catkin-tools libedgetpu1-legacy-std python3-edgetpu'
-            ROSDEP_SKIP_KEYS: 'python-numpy cv_bridge_python3'
+            ROSDEP_SKIP_KEYS: 'python python-numpy cv_bridge_python3'
             BEFORE_BUILD_TARGET_WORKSPACE: |
               cd /tmp && apt update && apt install -y wget python3-pip &&
               wget https://dl.google.com/coral/python/tflite_runtime-1.14.0-cp35-cp35m-linux_x86_64.whl &&

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
             UPSTREAM_WORKSPACE: '.ci.rosinstall.kinetic'
             UPSTREAM_CMAKE_ARGS: '-DPYTHON_EXECUTABLE=/usr/bin/python3 -DPYTHON_INCLUDE_DIR=/usr/include/python3.5m -DPYTHON_LIBRARY=/usr/lib/x86_64-linux-gnu/libpython3.5m.so'
             ADDITIONAL_DEBS: 'python3-catkin-pkg-modules python3-rospkg-modules python3-numpy ros-kinetic-opencv3 python3-venv python3-empy python-catkin-tools libedgetpu1-legacy-std python3-edgetpu'
-            ROSDEP_SKIP_KEYS: 'python-numpy cv_bridge_python3'
+            ROSDEP_SKIP_KEYS: 'python python-numpy cv_bridge_python3'
             BEFORE_BUILD_TARGET_WORKSPACE: |
               cd /tmp && apt update && apt install -y wget python3-pip &&
               wget https://dl.google.com/coral/python/tflite_runtime-1.14.0-cp35-cp35m-linux_x86_64.whl &&


### PR DESCRIPTION
Fix 
```
$ ( source /opt/ros/kinetic/setup.bash && rosdep install -q --from-paths /root/upstream_ws/src --ignore-src -y --skip-keys python-numpy cv_bridge_python3 | grep -E '(executing command)|(Setting up)' ; )
  ERROR: the following packages/stacks could not have their rosdep keys resolved
  to system dependencies:
  cv_bridge: No definition of [python] for OS version [xenial]
```